### PR TITLE
Add bower.json manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,28 @@
+{
+  "name": "rfc6902",
+  "description": "Complete implementation of RFC6902 (patch and diff)",
+  "main": "./rfc6902.js",
+  "authors": [
+    "Christopher Brown <io@henrian.com> (http://henrian.com)"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "json",
+    "patch",
+    "diff",
+    "rfc6902"
+  ],
+  "homepage": "https://github.com/chbrown/rfc6902",
+  "moduleType": [
+    "amd",
+    "es6",
+    "globals",
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test"
+  ]
+}


### PR DESCRIPTION
Bower manifest so `rfc9602` can be added to the bower registry.