### PR TITLE
Add docs for createTests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ const my_patch = createPatch(input, output, myDiff)
 ```
 This will short-circuit on encountering an instance of `MyObject`, but otherwise recurse as usual.
 
+### `createTest(input: any, patch: Operation[]): Operation[]`
+
+Returns a list of `test` JSON Patch operations to verify that
+existing values in an object are identical to the those captured at some
+checkpoint (whenever this function is called).
+
+The resulting operations don't modify the object. You can use the resulting
+operations to validate that an object is in the expected state before applying a
+patch.
+
+Sample usage:
+
+```js
+const patch = rfc6902.createPatch({first: 'Chris', last: 'Brown'}, {first: 'Chris', last: 'Smith'});
+const tests = rfc6902.createTests({first: 'Chris', last: 'Brown'}, patch);
+const problems = rfc6902.applyPatch({first: 'Chris', last: 'Cook'}, tests).filter(i => i != null);
+console.log([problem]);
+// [ Error [TestError]: Test failed: Cook != Brown ]
+```
+
 ### `Operation`
 
 ```typescript


### PR DESCRIPTION
I'm working on implementing a [3-way merge](https://en.wikipedia.org/wiki/Merge_(version_control)#Three-way_merge) for some JSON objects (take the diff from C to A and see if it can be cleanly applied to B), so the `createTests` method that was added for #16 is exactly what I'm looking for. However, I noticed that `createTests` is undocumented, so I added docs for it.

After I updated the docs, I noticed that `createTests` used to be documented, but the docs were removed in e407896. Is `createTests` still supported?