### PR TITLE
Test and tentative fix for #97

### DIFF
--- a/patch.ts
+++ b/patch.ts
@@ -110,7 +110,7 @@ export function replace(object: any, operation: ReplaceOperation): MissingError 
   else if (endpoint.value === undefined) {
     return new MissingError(operation.path)
   }
-  endpoint.parent[endpoint.key] = operation.value
+  endpoint.parent[endpoint.key] = clone(operation.value)
   return null
 }
 

--- a/test/issues.ts
+++ b/test/issues.ts
@@ -255,3 +255,15 @@ test('issues/78', t => {
   t.true(patch_results.every(result => result == null), 'should apply patch successfully')
   t.deepEqual(user['createdAt'].getTime(), 1281478248000, 'should add Date recoverably')
 })
+
+test('issues/97', t => {
+  const value = []
+  const document = {foo: ['baz']}
+  const patch_results = applyPatch(document, [
+    {op: 'replace', path: '/foo', value: value },
+    {op: 'add', path: '/foo/-', value: 'bar' },
+  ])
+  t.true(patch_results.every(result => result == null), 'should apply patch successfully')
+  t.deepEqual(document, {foo: ['bar']}, 'should alter document correctly')
+  t.true(value.length === 0); // array in patch object should not have been modified
+})


### PR DESCRIPTION
replace() seemed like the odd-one-out here, add() and copy() both use clone() on the patch operation value. Should move() perhaps also be cloning its value?