### PR TITLE
Fixes #104 - optional implicit array creation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,10 @@
 import {Pointer} from './pointer'
 export {Pointer}
 
-import {apply} from './patch'
+import {apply, Options} from './patch'
 import {Operation, TestOperation, isDestructive, Diff, VoidableDiff, diffAny} from './diff'
 
-export {Operation, TestOperation}
+export {Operation, TestOperation, Options}
 export type Patch = Operation[]
 
 /**
@@ -19,12 +19,15 @@ Apply a 'application/json-patch+json'-type patch to an object.
 
 This method mutates the target object in-place.
 
+@param object The object to apply the patch to
+@param patch Array of operations to apply
+@param options Optional customization of patch application behavior
 @returns list of results, one for each operation: `null` indicated success,
          otherwise, the result will be an instance of one of the Error classes:
          MissingError, InvalidOperationError, or TestError.
 */
-export function applyPatch(object: any, patch: Operation[]) {
-  return patch.map(operation => apply(object, operation))
+export function applyPatch(object: any, patch: Operation[], options?: Options) {
+  return patch.map(operation => apply(object, operation, options))
 }
 
 function wrapVoidableDiff(diff: VoidableDiff): Diff {

--- a/patch.ts
+++ b/patch.ts
@@ -1,5 +1,5 @@
 import {Pointer} from './pointer'
-import {clone} from './util'
+import {objectType, clone} from './util'
 import {AddOperation,
         RemoveOperation,
         ReplaceOperation,
@@ -8,6 +8,25 @@ import {AddOperation,
         TestOperation,
         Operation,
         diffAny} from './diff'
+
+export interface Options {
+  /**
+  When true, "add" operations with path ending in "/-" will implicitly
+  create an empty array where possible.
+
+  For example, with this option enabled, for the object `{live: true}`,
+  the operation `add "/tag/-" 123` will result in `{live: true, tag: [123]}`.
+  Subsequent operations behave normally: another `add "/tag/-" 456` will result
+  in `{live: true, tag: [123, 456]}`.
+
+  If the indicated array property already exists but is not an array, this will
+  produce an error.
+
+  Only the leaf array will be inferred; missing parent objects will still
+  produce errors.
+  */
+  implicitArrayCreation?: boolean
+}
 
 export class MissingError extends Error {
   constructor(public path: string) {
@@ -59,12 +78,31 @@ function _remove(object: any, key: string): void {
 >  o  If the target location specifies an object member that does exist,
 >     that member's value is replaced.
 */
-export function add(object: any, operation: AddOperation): MissingError | null {
-  const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
+export function add(object: any, operation: AddOperation, options?: Options): MissingError | null {
+  const pointer = Pointer.fromJSON(operation.path)
+  // Handle implicit array creation for terminal "/-" paths
+  if (options?.implicitArrayCreation && pointer.tokens[pointer.tokens.length - 1] === '-') {
+    // Try to evaluate the parent (the array itself)
+    const parentEndpoint = pointer.parent().evaluate(object)
+    // If the array property doesn't exist but its parent does,
+    // and this parent is a plain object (not an array),
+    // create an (empty) array that we will add to below.
+    if (parentEndpoint.value === undefined && objectType(parentEndpoint.parent) === 'object') {
+      parentEndpoint.parent[parentEndpoint.key] = []
+    }
+  }
+
+  const endpoint = pointer.evaluate(object)
   // it's not exactly a "MissingError" in the same way that `remove` is -- more like a MissingParent, or something
   if (endpoint.parent === undefined) {
     return new MissingError(operation.path)
   }
+
+  // When using implicitArrayCreation, validate that "/-" targets are actually arrays
+  if (options?.implicitArrayCreation && endpoint.key === '-' && !Array.isArray(endpoint.parent)) {
+    return new MissingError(operation.path)
+  }
+
   _add(endpoint.parent, endpoint.key, clone(operation.value))
   return null
 }
@@ -73,7 +111,7 @@ export function add(object: any, operation: AddOperation): MissingError | null {
 > The "remove" operation removes the value at the target location.
 > The target location MUST exist for the operation to be successful.
 */
-export function remove(object: any, operation: RemoveOperation): MissingError | null {
+export function remove(object: any, operation: RemoveOperation, options?: Options): MissingError | null {
   // endpoint has parent, key, and value properties
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
   if (endpoint.value === undefined) {
@@ -96,7 +134,7 @@ export function remove(object: any, operation: RemoveOperation): MissingError | 
 
 Even more simply, it's like the add operation with an existence check.
 */
-export function replace(object: any, operation: ReplaceOperation): MissingError | null {
+export function replace(object: any, operation: ReplaceOperation, options?: Options): MissingError | null {
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
   if (endpoint.parent === null) {
     return new MissingError(operation.path)
@@ -129,7 +167,7 @@ export function replace(object: any, operation: ReplaceOperation): MissingError 
 
 TODO: throw if the check described in the previous paragraph fails.
 */
-export function move(object: any, operation: MoveOperation): MissingError | null {
+export function move(object: any, operation: MoveOperation, options?: Options): MissingError | null {
   const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object)
   if (from_endpoint.value === undefined) {
     return new MissingError(operation.from)
@@ -156,7 +194,7 @@ export function move(object: any, operation: MoveOperation): MissingError | null
 
 Alternatively, it's like 'move' without the 'remove'.
 */
-export function copy(object: any, operation: CopyOperation): MissingError | null {
+export function copy(object: any, operation: CopyOperation, options?: Options): MissingError | null {
   const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object)
   if (from_endpoint.value === undefined) {
     return new MissingError(operation.from)
@@ -177,7 +215,7 @@ export function copy(object: any, operation: CopyOperation): MissingError | null
 > The target location MUST be equal to the "value" value for the
 > operation to be considered successful.
 */
-export function test(object: any, operation: TestOperation): TestError | null {
+export function test(object: any, operation: TestOperation, options?: Options): TestError | null {
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
   // TODO: this diffAny(...).length usage could/should be lazy
   if (diffAny(endpoint.value, operation.value, new Pointer()).length) {
@@ -197,17 +235,17 @@ export class InvalidOperationError extends Error {
 Switch on `operation.op`, applying the corresponding patch function for each
 case to `object`.
 */
-export function apply(object: any, operation: Operation): MissingError | InvalidOperationError | TestError | null {
+export function apply(object: any, operation: Operation, options?: Options): MissingError | InvalidOperationError | TestError | null {
   // not sure why TypeScript can't infer typesafety of:
   //   {add, remove, replace, move, copy, test}[operation.op](object, operation)
   // (seems like a bug)
   switch (operation.op) {
-    case 'add':     return add(object, operation)
-    case 'remove':  return remove(object, operation)
-    case 'replace': return replace(object, operation)
-    case 'move':    return move(object, operation)
-    case 'copy':    return copy(object, operation)
-    case 'test':    return test(object, operation)
+    case 'add':     return add(object, operation, options)
+    case 'remove':  return remove(object, operation, options)
+    case 'replace': return replace(object, operation, options)
+    case 'move':    return move(object, operation, options)
+    case 'copy':    return copy(object, operation, options)
+    case 'test':    return test(object, operation, options)
   }
   return new InvalidOperationError(operation)
 }

--- a/pointer.ts
+++ b/pointer.ts
@@ -99,4 +99,15 @@ export class Pointer {
     const tokens = this.tokens.concat(String(token))
     return new Pointer(tokens)
   }
+  /**
+  Create a new Pointer representing the parent of this one.
+
+  The parent of the empty pointer is the empty pointer.
+
+  immutable (shallowly)
+  */
+  parent(): Pointer {
+    const tokens = this.tokens.length > 1 ? this.tokens.slice(0, -1) : ['']
+    return new Pointer(tokens)
+  }
 }

--- a/test/patch.ts
+++ b/test/patch.ts
@@ -13,6 +13,33 @@ test('broken add', t => {
   t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
 })
 
+test('broken add (array does not exist)', t => {
+  const user = {id: 'chbrown'}
+  const results = applyPatch(user, [
+    {op: 'add', path: '/tag/-', value: 1},
+  ])
+  t.deepEqual(user, {id: 'chbrown'}, 'should change nothing')
+  t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
+test('working add (array exists)', t => {
+  const user = {id: 'chbrown', tag: []}
+  const results = applyPatch(user, [
+    {op: 'add', path: '/tag/-', value: 123},
+  ])
+  t.deepEqual(results, [null], 'should succeed')
+  t.deepEqual(user, {id: 'chbrown', tag: [123]}, 'should add tag')
+})
+
+test('working add (array exists and non-empty)', t => {
+  const user = {id: 'chbrown', tag: [999]}
+  const results = applyPatch(user, [
+    {op: 'add', path: '/tag/-', value: 123},
+  ])
+  t.deepEqual(results, [null], 'should succeed')
+  t.deepEqual(user, {id: 'chbrown', tag: [999, 123]}, 'should add tag')
+})
+
 test('broken remove', t => {
   const user = {id: 'chbrown'}
   const results = applyPatch(user, [
@@ -75,4 +102,90 @@ test('broken copy (path)', t => {
   ])
   t.deepEqual(user, {id: 'chbrown'}, 'should change nothing')
   t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
+// Option: implicitArrayCreation
+
+test('creates missing top-level array', t => {
+  const object = {}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/identifier/-', value: {system: 'mrn'}},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results, [null])
+  t.deepEqual(object, {identifier: [{system: 'mrn'}]})
+})
+
+test('creates missing nested array when parent exists', t => {
+  const object = {meta: {}}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/meta/tag/-', value: 'x'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results, [null])
+  t.deepEqual(object, {meta: {tag: ['x']}})
+})
+
+test('multiple appends to created array', t => {
+  const object = {meta: {}}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/meta/tag/-', value: 'a'},
+    {op: 'add', path: '/meta/tag/-', value: 'b'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results, [null, null])
+  t.deepEqual(object, {meta: {tag: ['a', 'b']}})
+})
+
+test('fails when parent object missing', t => {
+  const object = {}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/meta/tag/-', value: 'x'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
+})
+
+test('fails when parent is not object (value)', t => {
+  const object = {meta: true}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/meta/tag/-', value: 'x'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
+})
+
+test('fails when parent is not object (array)', t => {
+  const object = {meta: []}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/meta/tag/-', value: 'x'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
+})
+
+test('fails when parent is not object (null)', t => {
+  const object = {meta: null}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/meta/tag/-', value: 'x'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
+})
+
+test('fails on existing non-array property (value)', t => {
+  const object = {a: 1}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/a/-', value: 2},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
+})
+
+test('fails on existing non-array property (object)', t => {
+  const object = {a: {b: 2}}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/a/-', value: 2},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
+})
+
+test('fails on non-terminal /-', t => {
+  const object = {}
+  const results = applyPatch(object, [
+    {op: 'add', path: '/list/-/name', value: 'x'},
+  ], {implicitArrayCreation: true})
+  t.deepEqual(results.map(resultName), ['MissingError'])
 })

--- a/test/pointer.ts
+++ b/test/pointer.ts
@@ -20,6 +20,16 @@ test('Pointer.fromJSON invalid', t => {
   t.regex(error.message, /Invalid JSON Pointer/, 'thrown error should have descriptive message')
 })
 
+test('Pointer.parent', t => {
+  const pointer = Pointer.fromJSON('/abc/-')
+  const parent = pointer.parent()
+  t.deepEqual(parent.toString(), '/abc')
+  const grandParent = parent.parent()
+  t.deepEqual(grandParent.toString(), '')
+  const greatGrandParent = grandParent.parent()
+  t.deepEqual(greatGrandParent.toString(), '')
+})
+
 const example = {bool: false, arr: [10, 20, 30], obj: {a: 'A', b: 'B'}}
 
 test('Pointer#get bool', t => {


### PR DESCRIPTION
Hi @chbrown  - thanks again for all of your help with this.  Please let me know if you have any requests here (more tests, fewer tests, different implementation, whatever).  

--------

See #104 for full discussion

When working with FHIR resources (and similar document-oriented data), it's common to append to arrays that may or may not exist yet. Currently, appending to a missing array property requires checking existence first:            

```ts                                                                                                                                                                                              
  // Current: must ensure array exists                                                                                                                                                                                                 
  if (!resource.identifier) resource.identifier = []                                                                                                                                                                                   
  applyPatch(resource, [{op: 'add', path: '/identifier/-', value: {...}}])                                                                                                                                                             
```

This PR adds an opt-in option to handle this pattern more cleanly.                                                                                                                                                                   

Adds a new implicitArrayCreation option to applyPatch(). When enabled, add operations with terminal /- paths will create missing array properties:                                                                                   

```ts                                                                                                                                                                                                                                       
  // Before: errors with MissingError                                                                                                                                                                                                  
  applyPatch({}, [{op: 'add', path: '/identifier/-', value: {...}}])                                                                                                                                                                   
                                                                                                                                                                                                                                       
  // After: creates the array                                                                                                                                                                                                          
  applyPatch({}, [{op: 'add', path: '/identifier/-', value: {...}}],                                                                                                                                                                   
    {implicitArrayCreation: true})                                                                                                                                                                                                     
  // → {identifier: [{...}]}                                                                                                                                                                                                           
                                                                                                                                                                                                                                       
  // Nested case                                                                                                                                                                                                                       
  applyPatch({meta: {}}, [{op: 'add', path: '/meta/tag/-', value: 'x'}],                                                                                                                                                               
    {implicitArrayCreation: true})                                                                                                                                                                                                     
  // → {meta: {tag: ['x']}}                                                                                                                                                                                                            
```

Only creates the terminal array when:                                                                                                                                                                                                
  - Path ends with /- (array append)                                                                                                                                                                                                   
  - The immediate parent container exists                                                                                                                                                                                              
  - The parent is a plain object (not an array)                                                                                                                                                                                        
                                                                                                                                                                                                                                       
Still errors for:                                                                                                                                                                                                                    
  - Missing parent paths: {} + add /meta/tag/- → still MissingError                                                                                                                                                                    
  - Type conflicts: {a: 1} + add /a/- → still MissingError                                                                                                                                                                             
  - Non-terminal /-: add /list/-/name → still MissingError                                                                                                                                                                             
                                                                                                                                                                                                                                       
This avoids the complexity of "mkdir -p" style deep creation, where you'd need heuristics to decide whether intermediate paths should be objects or arrays.                                                                          
                                                                                                                                                                                                                                       
Implementation                                                                                                                                                                                                                       
                                                                                                                                                                                                                                       
  - Adds ApplyOptions interface with implicitArrayCreation (+ reserved implicitObjectCreation for future)                                                                                                                              
  - Updates applyPatch(object, patch, options?) signature                                                                                                                                                                              
  - Small addition to add() function in patch.ts (~15 lines)                                                                                                                                                                           
  - Validates that /- targets are actually arrays (returns MissingError instead of throwing)                                                                                                                                           
                                                                                                                                                                                                                                       
Backward compatibility                                                                                                                                                                                                               
                                                                                                                                                                                                                                       
  - Option defaults to false (off)                                                                                                                                                                                                     
  - All existing tests pass (108 total)                                                                                                                                                                                                
  - Error types unchanged when option is disabled                                                                                                                                                                                      
  - 9 new tests added to test/patch.ts                                                                                                                                                                                                 
                                                                                                                                                                                                                                       
Type definitions                                                                                                                                                                                                                     

```ts                                                                                                                                                                                                                                       
  export interface ApplyOptions {                                                                                                                                                                                                      
    implicitArrayCreation?: boolean                                                                                                                                                                                                    
    implicitObjectCreation?: boolean  // reserved for future                                                                                                                                                                           
  }                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                       
  applyPatch(object: any, patch: Operation[], options?: ApplyOptions)  
```