### PR TITLE
fix: return MissingError for add/remove/move/copy at the root pointer

### DIFF
--- a/patch.ts
+++ b/patch.ts
@@ -94,7 +94,7 @@ export function add(object: any, operation: AddOperation, options?: Options): Mi
 
   const endpoint = pointer.evaluate(object)
   // it's not exactly a "MissingError" in the same way that `remove` is -- more like a MissingParent, or something
-  if (endpoint.parent === undefined) {
+  if (endpoint.parent === undefined || endpoint.parent === null) {
     return new MissingError(operation.path)
   }
 
@@ -114,10 +114,13 @@ export function add(object: any, operation: AddOperation, options?: Options): Mi
 export function remove(object: any, operation: RemoveOperation, options?: Options): MissingError | null {
   // endpoint has parent, key, and value properties
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
+  // the root pointer "" has no parent to remove from (mirrors `replace`)
+  if (endpoint.parent === null) {
+    return new MissingError(operation.path)
+  }
   if (endpoint.value === undefined) {
     return new MissingError(operation.path)
   }
-  // not sure what the proper behavior is when path = ''
   _remove(endpoint.parent, endpoint.key)
   return null
 }
@@ -173,7 +176,7 @@ export function move(object: any, operation: MoveOperation, options?: Options): 
     return new MissingError(operation.from)
   }
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
-  if (endpoint.parent === undefined) {
+  if (endpoint.parent === undefined || endpoint.parent === null) {
     return new MissingError(operation.path)
   }
   _remove(from_endpoint.parent, from_endpoint.key)
@@ -200,7 +203,7 @@ export function copy(object: any, operation: CopyOperation, options?: Options): 
     return new MissingError(operation.from)
   }
   const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
-  if (endpoint.parent === undefined) {
+  if (endpoint.parent === undefined || endpoint.parent === null) {
     return new MissingError(operation.path)
   }
   _add(endpoint.parent, endpoint.key, clone(from_endpoint.value))

--- a/test/patch.ts
+++ b/test/patch.ts
@@ -13,6 +13,42 @@ test('broken add', t => {
   t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
 })
 
+test('add to the root pointer "" returns MissingError instead of throwing', t => {
+  const user = {a: 1}
+  const results = applyPatch(user, [
+    {op: 'add', path: '', value: {b: 2}},
+  ])
+  t.deepEqual(user, {a: 1}, 'should change nothing')
+  t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
+test('remove at the root pointer "" returns MissingError instead of throwing', t => {
+  const user = {a: 1}
+  const results = applyPatch(user, [
+    {op: 'remove', path: ''},
+  ])
+  t.deepEqual(user, {a: 1}, 'should change nothing')
+  t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
+test('move to the root pointer "" returns MissingError instead of throwing', t => {
+  const user = {a: 1}
+  const results = applyPatch(user, [
+    {op: 'move', from: '/a', path: ''},
+  ])
+  t.deepEqual(user, {a: 1}, 'should change nothing')
+  t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
+test('copy to the root pointer "" returns MissingError instead of throwing', t => {
+  const user = {a: 1}
+  const results = applyPatch(user, [
+    {op: 'copy', from: '/a', path: ''},
+  ])
+  t.deepEqual(user, {a: 1}, 'should change nothing')
+  t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
 test('broken add (array does not exist)', t => {
   const user = {id: 'chbrown'}
   const results = applyPatch(user, [


### PR DESCRIPTION
The README states `applyPatch` returns a list of `Error | null` and never throws. For the root pointer `""`, four operations throw an uncaught `TypeError` instead:

```js
applyPatch({a: 1}, [{op: "add",    path: "", value: {b: 2}}])  // throws TypeError
applyPatch({a: 1}, [{op: "remove", path: ""}])                 // throws TypeError
applyPatch({a: 1}, [{op: "move",   from: "/a", path: ""}])     // throws TypeError
applyPatch({a: 1}, [{op: "copy",   from: "/a", path: ""}])     // throws TypeError
applyPatch({a: 1}, [{op: "replace", path: "", value: {b: 2}}]) // returns [MissingError] (#32)
```

`Pointer.evaluate("")` returns `{parent: null, ...}`. `add`/`move`/`copy` guard with `endpoint.parent === undefined` and `remove` with `endpoint.value === undefined`, so the root pointer skips the guard and falls into `_add(null, "")` / `_remove(null, "")`. Only `replace` got the `parent === null` guard added in #32; its siblings were never updated.

This treats a null parent as missing in `add`/`move`/`copy` and adds the same guard to `remove`, so every root-targeted op returns a `MissingError` like `replace` does. Added tests for the four cases; full suite passes (108).