### PR TITLE
fix: correct diffArrays memoization key to avoid collisions

### DIFF
--- a/diff.ts
+++ b/diff.ts
@@ -206,7 +206,7 @@ export function diffArrays<T>(input: T[], output: T[], ptr: Pointer, diff: Diff 
   */
   function dist(i: number, j: number): DynamicAlternative {
     // memoized
-    const memo_key = i * max_length + j;
+    const memo_key = i * (max_length + 1) + j;
     let memoized = memo.get(memo_key)
     if (memoized === undefined) {
       // TODO: this !diff(...).length usage could/should be lazy

--- a/test/issues.ts
+++ b/test/issues.ts
@@ -267,3 +267,16 @@ test('issues/97', t => {
   t.deepEqual(user, {firstName: 'Chris', commits: ['5d565c8']}, 'should alter user correctly')
   t.is(commits.length, 0, 'original array should not be modified')
 })
+
+test('minimal array diff', t => {
+  // diffArrays is documented to compute the shortest sequence of operations,
+  // but a colliding memoization key made it return a sub-optimal patch here:
+  // removing the leading 'A' and appending 'C' is two operations, not three.
+  const input = ['A', 'B', 'A']
+  const output = ['B', 'A', 'C']
+  const expected_patch: Operation[] = [
+    {op: 'remove', path: '/0'},
+    {op: 'add', path: '/-', value: 'C'},
+  ]
+  checkRoundtrip(t, input, output, expected_patch)
+})


### PR DESCRIPTION
`diffArrays` memoizes its dynamic-programming cells with the key `i * max_length + j`, which is not injective: `j` reaches `output_length`, which can equal `max_length`, so e.g. with input length 2 and output length 3 the cells `(0, 3)` and `(1, 0)` both key to `3`. A cell then reuses another cell's memoized operation list and a shorter edit sequence is missed, so `diff` returns a non-minimal patch (it still round-trips).

Key the cells with `i * (max_length + 1) + j` so `(i, j)` is unique.
