### PR TITLE
fix: reject move when 'from' is a proper prefix of 'path'

### DIFF
--- a/patch.ts
+++ b/patch.ts
@@ -167,15 +167,21 @@ export function replace(object: any, operation: ReplaceOperation, options?: Opti
 
 > The "from" location MUST NOT be a proper prefix of the "path"
 > location; i.e., a location cannot be moved into one of its children.
-
-TODO: throw if the check described in the previous paragraph fails.
 */
 export function move(object: any, operation: MoveOperation, options?: Options): MissingError | null {
-  const from_endpoint = Pointer.fromJSON(operation.from).evaluate(object)
+  const from_pointer = Pointer.fromJSON(operation.from)
+  const from_endpoint = from_pointer.evaluate(object)
   if (from_endpoint.value === undefined) {
     return new MissingError(operation.from)
   }
-  const endpoint = Pointer.fromJSON(operation.path).evaluate(object)
+  const pointer = Pointer.fromJSON(operation.path)
+  // a location cannot be moved into one of its own children; doing so would
+  // detach the destination along with the value and silently lose data
+  if (from_pointer.tokens.length < pointer.tokens.length &&
+      from_pointer.tokens.every((token, index) => token === pointer.tokens[index])) {
+    return new MissingError(operation.path)
+  }
+  const endpoint = pointer.evaluate(object)
   if (endpoint.parent === undefined || endpoint.parent === null) {
     return new MissingError(operation.path)
   }

--- a/test/patch.ts
+++ b/test/patch.ts
@@ -122,6 +122,17 @@ test('broken move (path)', t => {
   t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
 })
 
+test('move into own child returns MissingError instead of destroying data', t => {
+  // RFC 6902 4.4: "The 'from' location MUST NOT be a proper prefix of the
+  // 'path' location; i.e., a location cannot be moved into one of its children."
+  const doc = {a: {b: {}}}
+  const results = applyPatch(doc, [
+    {op: 'move', from: '/a', path: '/a/b/c'},
+  ])
+  t.deepEqual(doc, {a: {b: {}}}, 'should change nothing')
+  t.deepEqual(results.map(resultName), ['MissingError'], 'should result in MissingError')
+})
+
 test('broken copy (from)', t => {
   const user = {id: 'chbrown'}
   const results = applyPatch(user, [


### PR DESCRIPTION
RFC 6902 §4.4 requires that a `move` operation's `from` location must not be a proper prefix of its `path` — a location cannot be moved into one of its own children. That check was an unimplemented `TODO`, so such a move removed the `from` subtree (detaching the destination), then added the value into the now-orphaned parent, silently losing data and returning success:

```js
applyPatch({a: {b: {}}}, [{op: 'move', from: '/a', path: '/a/b/c'}])
// document becomes {}   (expected unchanged, with a MissingError)
```

Return a `MissingError` before mutating when `from` is a proper prefix of `path`.
